### PR TITLE
Edit Bump version and migrate protobuf url to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ is a Clojure wrapper around the Java protobuf API.
 
 Add the following to your `project.clj` file:
 
-    :plugins [[lein-protobuf "0.1.1"]]
+    :plugins [[lein-protobuf "0.4.2"]]
 
-Replace `"0.1.1"` with the actual latest version, which you can find at http://clojars.org/lein-protobuf.
+Replace `"0.4.2"` with the actual latest version, which you can find at http://clojars.org/lein-protobuf.
 
 *Note: lein-protobuf requires at least version 2.0 of Leiningen.*
 
@@ -20,20 +20,20 @@ directory. This was chosen as the default location so that `.proto` files would 
 your jar files. You can change this with:
 
     :proto-path "path/to/proto"
-    
+
 To compile all `.proto` files in this directory, just run:
 
     lein protobuf
-    
+
 You can also compile specific proto files with:
 
     lein protobuf file1.proto file2.proto
-    
+
 We also add a hook to Leiningen's `compile` task, so `.proto` files will automatically be compiled
 before that task runs. So if you like, you can simply run:
 
     lein compile
-    
+
 
 ## Getting Help
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-protobuf "0.4.1"
+(defproject lein-protobuf "0.4.2"
   :description "Leiningen plugin for compiling protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/leiningen/protobuf.clj
+++ b/src/leiningen/protobuf.clj
@@ -10,7 +10,7 @@
             [conch.core :as sh]))
 
 (def cache (io/file (leiningen-home) "cache" "lein-protobuf"))
-(def default-version "2.5.0")
+(def default-version "2.6.1")
 
 (defn version [project]
   (or (:protobuf-version project) default-version))
@@ -26,7 +26,9 @@
 
 (defn url [project]
   (java.net.URL.
-   (format "http://protobuf.googlecode.com/files/protobuf-%s.zip" (version project))))
+   (format "https://github.com/google/protobuf/releases/download/v%s/protobuf-%s.zip"
+     (version project)
+     (version project))))
 
 (defn proto-path [project]
   (io/file (get project :proto-path "resources/proto")))


### PR DESCRIPTION
New releases are now hosted at Github.com
Also see: https://github.com/ninjudd/lein-protobuf/pull/11
