### PR TITLE
Support java 6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.brunchboy/lein-protobuf "0.4.3-SNAPSHOT"
+(defproject lein-protobuf "0.4.3"
   :description "Leiningen plugin for compiling protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-protobuf "0.4.2"
+(defproject org.clojars.brunchboy/lein-protobuf "0.4.3-SNAPSHOT"
   :description "Leiningen plugin for compiling protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/leiningen/protobuf.clj
+++ b/src/leiningen/protobuf.clj
@@ -133,7 +133,7 @@
                    (abort "ERROR:" (sh/stream-to-string result :err))))))
            (javac (assoc project
                     :java-source-paths [(.getPath dest)]
-                    :javac-options ["-Xlint:none"])))))))
+                    :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:none"])))))))
 
 (defn compile-google-protobuf
   "Compile com.google.protobuf.*"


### PR DESCRIPTION
Even though Clojure itself generates classes that are compatible back to Java 6, lein-protobuf is compiling to whatever JVM version happens to be installed on the developer's machine. This is a problem because I want to be able to use protobuf in my open-source lighting controller [Afterglow](https://github.com/brunchboy/afterglow#afterglow), and be able to host that within [Cycling ‘74’s Max](https://cycling74.com/), which only supports the legacy Apple Java 6 implementation on the Mac.

This change tells Leiningen to run `javac` with arguments that create Java 6 compatible class files even if it is being run with a newer JDK.
